### PR TITLE
ENH/BF?: helper to rule out absent library path + pass winmode=0

### DIFF
--- a/setup_configure.py
+++ b/setup_configure.py
@@ -227,6 +227,9 @@ class HDF5LibWrapper:
 
         self._lib_path = path
 
+        if op.isabs(path) and not op.exists(path):
+            raise FileNotFoundError(f"{path} is missing")
+
         try:
             lib = ctypes.cdll.LoadLibrary(path)
         except Exception:


### PR DESCRIPTION
it is a bit blind attempt... meanwhile not yet there in a windows vm to try it out, so would be nice to just merge or CP into your branch on the original PR   https://github.com/h5py/h5py/pull/1755 , or add me as a collab to your fork so I could push directly to ruin it all ;)